### PR TITLE
Generate docs from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bundle.js
 bundle.js.map
 /lib
+/generated-docs.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /examples
+/tools

--- a/README.md
+++ b/README.md
@@ -15,164 +15,32 @@ npm install --save react-abstract-autocomplete
 For usage examples, check out the [Examples] page, and the projects in the
 [examples/][Examples source code] directory.
 
+<!-- Docs are generated using `npm run docs` and copy-pasted here: -->
+
 ### AutoComplete
-
-<!--
-  Whelp… HTML tables, because GFM doesn't do multiline cell content, I think?
--->
-
-<table>
-  <thead>
-    <tr>
-      <th>Prop</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`inputComponent`</td>
-      <td>`'input'`</td>
-      <td>
-        Component to use for rendering the input element. Uses native `<input />`
-        by default. <br>
-        The component should accept `value`, `onChange` and `onKeyDown` props.
-      </td>
-    </tr>
-    <tr>
-      <td>`inputProps`</td>
-      <td>`{}`</td>
-      <td>Props to pass to the input component.</td>
-    </tr>
-    <tr>
-      <td>`children`</td>
-      <td></td>
-      <td>[Completion types][#completion] as `<Completion />` elements.</td>
-    </tr>
-    <tr>
-      <td>`limit`</td>
-      <td>15</td>
-      <td>The maximum amount of suggestions to show.</td>
-    </tr>
-    <tr>
-      <td>`renderSuggestions`</td>
-      <td>`<div>{suggestions}</div>`</td>
-      <td>
-        Function that renders the suggestions list. <br>
-        Signature: `(suggestions: Array<element>) => element` <br>
-      </td>
-    </tr>
-    <tr>
-      <td>`renderSuggestion`</td>
-      <td>
-        `<div key={key} onClick={select}>{value}</div>`
-      </td>
-      <td>
-        Function that renders a single suggestion. This can be overridden for
-        individual Completion types, in case they need custom rendering. <br>
-        Signature: `(suggestion: object) => element` <br>
-        _suggestion.key_ `string` - Unique key for the suggestion element. See
-          [Dynamic Children] for details. <br>
-        _suggestion.value_ `any` - Completion value of this suggestion. <br>
-        _suggestion.selected_ `boolean` - Whether this suggestion is currently
-        selected. <br>
-        _suggestion.select_ `function` - Autocomplete this suggestion.
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Name | Type | Default | Description |
+|:-----|:-----|:-----|:-----|
+| inputComponent | one of:<br>&nbsp;string<br>&nbsp;function<br> | 'input' | Component to use for rendering the input element. Uses native `<input />` by default.<br>The component should accept `value`, `onChange` and `onKeyDown` props. |
+| inputProps | object | {} | Props to pass to the input component. |
+| renderSuggestion | function | `<div key={key} onClick={select}>{value}</div>` | Function that renders a single suggestion. This can be overridden for individual Completion types, in case they need custom rendering.<br><br>**Signature:**<br>`function(suggestion: Object) => element`<br>*suggestion:* Suggestion descriptor.<br>*suggestion.key:* Unique key for the suggestion element.     See [Dynamic Children](https://facebook.github.io/react/docs/multiple-components.html#dynamic-children)     for details.<br>*suggestion.value:* Completion value of this suggestion.<br>*suggestion.selected:* Whether this suggestion is     currently selected.<br>*suggestion.select:* Autocomplete this suggestion. |
+| renderSuggestions | function | `<div>{suggestions}</div>` | Function that renders the suggestions list.<br><br>**Signature:**<br>`function(suggestions: Array) => element`<br>*suggestions:* Array of children rendered by     `renderSuggestion`. |
+| children | node |  | Completion types as [`<Completion />`][Completion] elements. |
+| limit | number | 15 | The maximum amount of suggestions to show. |
 
 ### Completion
 
-`<Completion />` elements describe different data sources. Multiple can be used
-in the same [`<AutoComplete />`][AutoComplete] component.
+`<Completion />` elements describe different data sources. Multiple can be
+used in the same [`<AutoComplete />`][AutoComplete] component.
 
-<table>
-  <thead>
-    <tr>
-      <th>Prop</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`trigger` (required)</td>
-      <td></td>
-      <td>String that triggers this completion type.</td>
-    </tr>
-    <tr>
-      <td>`minLength`</td>
-      <td>3</td>
-      <td>Minimum amount of characters typed before suggestions will be given.</td>
-    </tr>
-    <tr>
-      <td>`regex`</td>
-      <td>`/.*(<trigger>.*?)$/`</td>
-      <td>
-        <p>Regex to extract the current completion value from the input. Can also
-        be used to "validate" the current completion value, so no suggestions
-        will be provided if it's "invalid".</p>
-
-        <p>Uses the first capture group as the value to be completed, or the full
-        match if there are no capture groups. For example:</p>
-
-        <ul>
-          <li>`/.*(@.*?)$/` + `"Hello @ReA"` → `"@ReA"`</li>
-          <li>`/\w+$/` + `"This is sp"` → `"sp"`</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>`limit`</td>
-      <td>15</td>
-      <td>The maximum amount of suggestions to show.</td>
-    </tr>
-    <tr>
-      <td>`renderSuggestion`</td>
-      <td></td>
-      <td>
-        Optional override of the [`<AutoComplete />`][AutoComplete]'s
-        `renderSuggestion` prop, with the same behaviour.
-      </td>
-    </tr>
-    <tr>
-      <td>`getCompletions`</td>
-      <td>Searches `completions` prop by default</td>
-      <td>
-        Get an array of possible completions. <br>
-        Signature: `(matchingValue: string, props: object) => array` <br>
-        _matchingValue_ - Current value to be completed, as extracted using
-        `props.regex`. <br>
-        _props_ - Props passed to this `<Completion />` element.
-      </td>
-    </tr>
-    <tr>
-      <td>`completions`</td>
-      <td></td>
-      <td>
-        Optional array of completion values. This can be used if all possible
-        completions are known beforehand. If provided, a default `getCompletions`
-        function that searches this array will be used.
-      </td>
-    </tr>
-    <tr>
-      <td>`getText`</td>
-      <td>
-        `(value, props) => props.trigger + value + ' '`
-      </td>
-      <td>
-        Transform a completion value to a string that will be inserted into the
-        input component. By default, uses `${props.trigger}${value} `. (Note the
-        space at the end! If you want to add a space once a completion is
-        inserted, add it here.) <br>
-        Signature: `(value: any, props: object) => string` <br>
-        _value_ - Completion value. <br>
-        _props_ - Props of this `<Completion />` element.
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Name | Type | Default | Description |
+|:-----|:-----|:-----|:-----|
+| trigger _(required)_ | one of:<br>&nbsp;string<br>&nbsp;RegExp<br> |  | String that triggers this completion type. |
+| minLength | number | 3 | Minimum amount of characters typed before suggestions will be given. |
+| regex | RegExp |  | Regex to extract the current completion value from the input. Can also be used to "validate" the current completion value, so no suggestions will be provided if it's "invalid".<br>Uses the first capture group as the value to be completed, or the full match if there are no capture groups. For example:  - /.*(@.*?)$/ + "Hello @ReA" → "@ReA"  - /\w+$/ + "This is sp" → "sp" |
+| renderSuggestion | function |  | Function that renders a single suggestion.<br><br>**Signature:**<br>`function(suggestion: Object) => element`<br>*suggestion:* Suggestion descriptor.<br>*suggestion.key:* Unique key for the suggestion element.     See [Dynamic Children](https://facebook.github.io/react/docs/multiple-components.html#dynamic-children)     for details.<br>*suggestion.value:* Completion value of this suggestion.<br>*suggestion.selected:* Whether this suggestion is     currently selected.<br>*suggestion.select:* Autocomplete this suggestion. |
+| getCompletions | function | Searches the `completions` prop. | Get an array of possible completions.<br><br>**Signature:**<br>`function(matchingValue: string, props: Object) => undefined`<br>*matchingValue:* Current value to be completed, as     extracted using `props.regex`.<br>*props:* Props of this `<Completion />` element. |
+| completions | array |  | Optional array of completion values. This can be used if all possible completions are known beforehand. If provided, a default `getCompletions` function that searches this array will be used. |
+| getText | function | (value, { trigger }) => `${trigger}${value} ` | Transform a completion value to a string that will be inserted into the input component. By default, uses `${props.trigger}${value} `. (Note the space at the end! If you want to add a space once a completion is inserted, add it here.)<br><br>**Signature:**<br>`function(value: undefined, props: Object) => string`<br>*value:* Completion value.<br>*props:* Props of this `<Completion />` element. |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "gulp",
+    "docs": "node tools/generate-docs.js > generated-docs.md",
     "lint": "eslint .",
     "test": "npm run lint && mocha"
   },
@@ -34,6 +35,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.9.0",
+    "doctrine": "^1.3.0",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.2",
@@ -47,6 +49,7 @@
     "gulp-watch": "^4.3.8",
     "mocha": "^2.4.5",
     "react": "^15.2.1",
+    "react-docgen": "^2.10.0",
     "react-dom": "^15.2.1",
     "rollup": "^0.34.13",
     "rollup-plugin-babel": "^2.6.1",

--- a/src/Completion.js
+++ b/src/Completion.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 /**
- *
+ * `<Completion />` elements describe different data sources. Multiple can be
+ * used in the same [`<AutoComplete />`][AutoComplete] component.
  */
 class Completion extends React.Component {
   static propTypes = {
@@ -44,12 +45,14 @@ class Completion extends React.Component {
     /**
      * Get an array of possible completions.
      *
+     * @default Searches the `completions` prop.
+     *
      * @param {string} matchingValue - Current value to be completed, as
      *     extracted using `props.regex`.
      * @param {Object} props - Props of this `<Completion />` element.
      * @returns {Array.<*>}
      */
-    getCompletions: React.PropTypes.func.isRequired,
+    getCompletions: React.PropTypes.func,
     /**
      * Optional array of completion values. This can be used if all possible
      * completions are known beforehand. If provided, a default `getCompletions`

--- a/src/Completion.js
+++ b/src/Completion.js
@@ -31,7 +31,7 @@ class Completion extends React.Component {
     /**
      * Function that renders a single suggestion.
      *
-     * @param {Object} suggestion
+     * @param {Object} suggestion - Suggestion descriptor.
      * @param {string} suggestion.key - Unique key for the suggestion element.
      *     See [Dynamic Children](https://facebook.github.io/react/docs/multiple-components.html#dynamic-children)
      *     for details.

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,9 @@ class AutoComplete extends React.Component {
      * Function that renders a single suggestion. This can be overridden for
      * individual Completion types, in case they need custom rendering.
      *
-     * @param {Object} suggestion
+     * @default `<div key={key} onClick={select}>{value}</div>`
+     *
+     * @param {Object} suggestion - Suggestion descriptor.
      * @param {string} suggestion.key - Unique key for the suggestion element.
      *     See [Dynamic Children](https://facebook.github.io/react/docs/multiple-components.html#dynamic-children)
      *     for details.
@@ -51,12 +53,15 @@ class AutoComplete extends React.Component {
     /**
      * Function that renders the suggestions list.
      *
-     * @param {Array.<React.Component>} suggestions
+     * @default `<div>{suggestions}</div>`
+     *
+     * @param {Array} suggestions - Array of children rendered by
+     *     `renderSuggestion`.
      * @returns {element}
      */
     renderSuggestions: React.PropTypes.func,
     /**
-     * Completion types as <Completion /> elements.
+     * Completion types as [`<Completion />`][Completion] elements.
      */
     children: React.PropTypes.node,
     /**

--- a/tools/generate-docs.js
+++ b/tools/generate-docs.js
@@ -1,0 +1,132 @@
+/**
+ * Auto-generate documentation from the component's propTypes.
+ * Adapted from Material-UI's PropTypeDescription component:
+ *  https://github.com/callemall/material-ui/blob/82482758573dc714b210529dcf092dab904db0ba/docs/src/app/components/PropTypeDescription.js
+ * (c) Call-Em-All
+ */
+
+const fs = require('fs');
+const parse = require('react-docgen').parse;
+const parseDoctrine = require('doctrine').parse;
+
+function generatePropType(type) {
+  switch (type.name) {
+    case 'func':
+      return 'function';
+    case 'custom':
+      return type.raw;
+    case 'instanceOf':
+      return type.value;
+    case 'enum': {
+      const values = type.value.map((v) => v.value).join('<br>&nbsp;');
+      return `enum:<br>&nbsp;${values}<br>`;
+    }
+    case 'union': {
+      const values = type.value.map(generatePropType).join('<br>&nbsp;');
+      return `one of:<br>&nbsp;${values}<br>`;
+    }
+    default:
+      return type.name;
+  }
+}
+
+function generateDescription(parsed, tags, type) {
+  // two new lines result in a newline in the table. all other new lines
+  // must be eliminated to prevent markdown mayhem.
+  const jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ');
+
+  if (parsed.tags.some((tag) => tag.title === 'ignore')) {
+    return null;
+  }
+  let signature = '';
+
+  if (type.name === 'func' && parsed.tags.length > 0) {
+    const parsedArgs = tags.param || [];
+    const parsedReturns = tags.returns && tags.returns[0] || {
+      type: { name: 'void' },
+    };
+
+    signature += '<br><br>**Signature:**<br>`function(';
+    signature += parsedArgs
+      .filter(tag => tag.name.indexOf('.') === -1)
+      .map(tag => `${tag.name}: ${tag.type.name}`)
+      .join(', ');
+    signature += `) => ${parsedReturns.type.name}\`<br>`;
+    signature += parsedArgs
+      .map(tag => `*${tag.name}:* ${tag.description}`)
+      .join('<br>');
+    if (parsedReturns.description) {
+      signature += `<br> *returns* (${parsedReturns.type.name}): ${parsedReturns.description}`;
+    }
+  }
+
+  return `${jsDocText}${signature}`;
+}
+
+function generateRow(prop) {
+  const parsed = parseDoctrine(prop.description);
+
+  const parsedTags = {};
+  parsed.tags.forEach(tag => {
+    if (!parsedTags[tag.title]) {
+      parsedTags[tag.title] = [];
+    }
+    // Remove new lines from tag descriptions to avoid markdown errors.
+    if (tag.description) {
+      // eslint-disable-next-line no-param-reassign
+      tag.description = tag.description.replace(/\n/g, ' ');
+    }
+    parsedTags[tag.title].push(tag);
+  });
+
+  let defaultValue = '';
+  if (parsedTags.default && parsedTags.default.length > 0) {
+    defaultValue = parsedTags.default[0].description;
+  } else if (prop.defaultValue) {
+    defaultValue = prop.defaultValue.value.replace(/\n/g, '');
+  }
+
+  return {
+    type: generatePropType(prop.type),
+    default: defaultValue,
+    description: generateDescription(parsed, parsedTags, prop.type),
+  };
+}
+
+function render(code) {
+  const componentInfo = parse(code);
+
+  let text =
+    (componentInfo.description ? `\n${componentInfo.description}\n\n` : '') +
+    '| Name | Type | Default | Description |\n' +
+    '|:-----|:-----|:-----|:-----|\n';
+
+  for (let key of Object.keys(componentInfo.props)) {
+    const prop = componentInfo.props[key];
+
+    const row = generateRow(prop);
+
+    if (row.description === null) continue;
+
+    if (prop.required) {
+      key += ' _(required)_';
+    }
+
+    text += `| ${key} | ${row.type} | ${row.default} | ${row.description} |\n`;
+  }
+
+  return text;
+}
+
+function gen(file) {
+  const source = fs.readFileSync(file, 'utf8')
+    // react-docgen doesn't pick up on "import * as React" for some reason, so
+    // hack around that
+    .replace('* as React', 'React');
+  return render(source);
+}
+
+console.log('### AutoComplete');
+console.log(gen('src/index.js'));
+console.log('### Completion');
+console.log(gen('src/Completion.js'));


### PR DESCRIPTION
Apparently github doesn't render Markdown inside HTML tables. I don't want to edit really long lines with lots of `<br>`s by hand so using this instead.

This doc generation script comes from material-ui originally.

It's modded a bit to interpret an `@default` annotation, some of the default functions would take up a lot of space and be barely readable otherwise. `getCompletions` now just has a description of the behaviour under its default column for example.